### PR TITLE
Reducing API calls to once per run, not once per coin

### DIFF
--- a/contribute.md
+++ b/contribute.md
@@ -1,0 +1,23 @@
+# Crypto Sheets Contribution Guidelines
+
+This script is aimed at being user friendly, with the eventual goal of users not having to edit the script at all.  Please check the open issues and add new ones for additional features or bugs.
+
+## This project utilizes GitFlow
+
+Please create new feature branches for new functionality.  These branches will then be merged into the `develop` branch for further testing and review until packaged into a new `release` and merged back into `master`.
+
+For general GitFlow guidelines and best practices, please consult [Atlassian's GitFlow Tutorial](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow).
+
+## Chat with other devs
+
+I have created a gitter community at https://gitter.im/cryptosheets/development
+
+## Reddit
+
+Please promote the use of our subreddit for user help.  If you're a contributor to the project, feel free to request moderator privileges.  Users should also be encouraged to create GitHub issues, or create issues based on commonly seen issues.
+
+https://www.reddit.com/r/cryptosheets/
+
+## License
+
+This project is licensed under the GNU General Public License v3.0

--- a/scripteditor.js
+++ b/scripteditor.js
@@ -1,6 +1,15 @@
 var queryString = Math.random();
 
+// Set the target currency
+// Possible values: 
+  //"aud", "brl", "cad", "chf", "clp", "cny", "czk", "dkk", "eur", "gbp", "hkd", "huf", 
+  //"idr", "ils", "inr", "jpy", "krw", "mxn", "myr", "nok", "nzd", "php", "pkr", "pln", 
+  //"rub", "sek", "sgd", "thb", "try", "twd", "usd", "zar"
+    
+var targetCurrency = 'usd'
+
 function getData() {
+  
   var ss = SpreadsheetApp.getActiveSpreadsheet();
   
   //
@@ -10,64 +19,62 @@ function getData() {
 
   //This fetches all the data from CoinMarketCapAPI
   //IMPORTANT: DO NOT TOUCH THIS LINE
-  var apiObj = getApiObj();
+  var currencyArr = getcurrencyArr();
 
-  //Grabbing values from CoinMarketCapAPI data
+  //Grabbing values from CoinMarketCapAPI
   //Change the variable name to match the trading symbol
-  //Change the name in the quotes (e.g. are-bees-carebears) to match the 'id' field from https://api.coinmarketcap.com/v1/ticker/
-  //Copy/paste to add more lines as needed
+  //Change the name in the quotes (e.g. are-bees-carebears) to match the currency 'id':
+  // - currency id is either id as found in field from https://api.coinmarketcap.com/v1/ticker/
+  // - or last part or URL for CoinMarketCap page for the currency (e.g. 'zeeyx' for https://coinmarketcap.com/currencies/zeeyx)
+  //Copy and paste to add more lines as needed
   
-  var ABC = getRate('are-bees-carebears', apiObj);
-  var BCD = getRate('berry-cool-doge', apiObj);
-  var CDE = getRate('coin-dank-enigma', apiObj);
-  
+  var ARK = getRate('ark');
+  var BCH = getRate('bitcoin-cash');
+  var CNX = getRate('cryptonex');
+
   //Grabbing values that are on CoinMarketCap but not in the API
   //Change the variable name to match the trading symbol
   //Go to the CoinMarketCap page for the currency (e.g. https://coinmarketcap.com/currencies/zeeyx)
   //Change the name in quotes (e.g. zeeyx) to match the end of the URL for your currency
-  //Copy/paste to add more lines as needed
+  //Copy and paste to add more lines as needed
   
-  var ZYX = getWebRate('zeeyx');
-  var YXW = getWebRate('yaaxw');
-  var XWV = getWebRate('xoowv');
-
+  //var ZYX = getWebRate('zeeyx');
+  //var YXW = getWebRate('yaaxw');
+  //var XWV = getWebRate('xoowv');
+  
   //Setting values in a sheet called 'Rates' (defined at the top)
   //Change the values in getRange() to match the cells in the 'Rates' sheet you want to userAgent
   //Use the coin symbols from above in setValue()
-
-  ssRates.getRange('B1').setValue(ABC);
-  ssRates.getRange('B2').setValue(BCD);
-  ssRates.getRange('B3').setValue(CDE);
   
-  ssRates.getRange('B4').setValue(ZYX);
-  ssRates.getRange('B5').setValue(YXW);
-  ssRates.getRange('B6').setValue(XWV);
-
+  ssRates.getRange('B1').setValue(ARK);
+  ssRates.getRange('B2').setValue(BCH);
+  ssRates.getRange('B3').setValue(CNX);
+  
   //VTC wallet balances
   //Add more as needed with different variable names
-
-  var VtcWallet = getVtcBalance("yourAddressHere");
-
+  
+  //var VtcWallet = getVtcBalance("yourAddressHere");
+  
   //Change the value in getRange() to match the cell in spreadsheet
   //Change the value in setValue() to match the variable above
-
-  ssRates.getRange('E3').setValue(VtcWallet);
-
+  
+  //ssRates.getRange('E3').setValue(VtcWallet);
+  
   //Ethereum Wallet Balances
   //Create an account on Etherscan.io
   //Create an API key at https://etherscan.io/myapikey
   //Put your API key in below, replacing yourEtherscanApiKey
   //Add Ethereum address, replacing yourEthAddress
-
-  var EthApiKey = "yourEtherscanApiKey";
-  var EthWallet = getEthBalance(EthApiKey,"yourEthAddress");
-
+  
+  //var EthApiKey = "yourEtherscanApiKey";
+  //var EthWallet = getEthBalance(EthApiKey,"yourEthAddress");
+  
   //Putting this value in spreadsheet
   //Change the value in setValue() to match the variable above
-
-  ssRates.getRange('E1').setValue(EthWallet);
+  
+  //ssRates.getRange('E1').setValue(EthWallet);
 }
-
+  
   //
   // DON'T TOUCH ANYTHING BELOW
   // IT MAKES THE MAGIC HAPPEN
@@ -77,37 +84,45 @@ function getEthBalance(ethApiKey,ethAddress) {
 
   var obj = JSON.parse (UrlFetchApp.fetch("https://api.etherscan.io/api?module=account&action=balance&address="+ethAddress+"&tag=latest&apikey="+ethApiKey));
   var data = (obj.result);
-
+  
   return data * Math.pow(10,-18);
 }
 
 function getVtcBalance(vtcAddress) {
 
-  var obj = UrlFetchApp.fetch("http://explorer.vertcoin.info/ext/getbalance/"+vtcAddress);
-
+  var obj = UrlFetchApp.fetch("http://explorer.vertcoin.info/ext/getbalance/"+vtcAddress);     
+  
   return obj;
 }
 
-function getApiObj() {
-  var url = 'https://api.coinmarketcap.com/v1/ticker/';
+function getcurrencyArr() {
+  if (typeof targetCurrency !== 'undefined') {conversionRate = 'usd'};
+
+  var url = 'https://api.coinmarketcap.com/v1/ticker/?limit=0&convert=' + targetCurrency;
   var response = UrlFetchApp.fetch(url, {'muteHttpExceptions': true});
   var json = response.getContentText();
 
   return JSON.parse(json);
 }
 
-function getRate(currencyId, apiObj) {
-  var currencyData = apiObj.filter(function(obj) {
+function getRate(currencyId, currencyArr) {
+  var currencyData = currencyArr.filter(function(obj) {
     return obj.id == currencyId;
   });
 
-  return parseFloat(currencyData[0].price_usd);
+  if (currencyData.length < 1) {
+    // currencyId not found in fetched API data, we'll return error for now
+    // future idea: try to get from webpage (maybe coin just not in API yet)
+    return "Coin not found"
+  }
+
+  return parseFloat(currencyData[0]['price_' + targetCurrency]);
 }
 
 function getWebRate(currencyId) {
   //Example Output: 
   // '=IMPORTXML("https://coinmarketcap.com/currencies/zeeyx?3908288283","//span[@id=\'quote_price\']")';	
-	
+  
   var coinScrape1 = '=IMPORTXML("https://coinmarketcap.com/currencies/';
   var coinScrape2 = '","//span[@id=\'quote_price\']")';
   

--- a/scripteditor.js
+++ b/scripteditor.js
@@ -8,14 +8,18 @@ function getData() {
   //
   var ssRates = ss.getSheetByName('Rates');
 
-  //Grabbing values from CoinMarketCapAPI
+  //This fetches all the data from CoinMarketCapAPI
+  //IMPORTANT: DO NOT TOUCH THIS LINE
+  var apiObj = getApiObj();
+
+  //Grabbing values from CoinMarketCapAPI data
   //Change the variable name to match the trading symbol
   //Change the name in the quotes (e.g. are-bees-carebears) to match the 'id' field from https://api.coinmarketcap.com/v1/ticker/
   //Copy/paste to add more lines as needed
   
-  var ABC = getRate('are-bees-carebears');
-  var BCD = getRate('berry-cool-doge');
-  var CDE = getRate('coin-dank-enigma');
+  var ABC = getRate('are-bees-carebears', apiObj);
+  var BCD = getRate('berry-cool-doge', apiObj);
+  var CDE = getRate('coin-dank-enigma', apiObj);
   
   //Grabbing values that are on CoinMarketCap but not in the API
   //Change the variable name to match the trading symbol
@@ -84,14 +88,20 @@ function getVtcBalance(vtcAddress) {
   return obj;
 }
 
-function getRate(currencyId) {
-
-  var url = 'https://api.coinmarketcap.com/v1/ticker/' + currencyId + '/';
+function getApiObj() {
+  var url = 'https://api.coinmarketcap.com/v1/ticker/';
   var response = UrlFetchApp.fetch(url, {'muteHttpExceptions': true});
   var json = response.getContentText();
-  var data = JSON.parse(json);
 
-  return parseFloat(data[0]['price_usd']);
+  return JSON.parse(json);
+}
+
+function getRate(currencyId, apiObj) {
+  var currencyData = apiObj.filter(function(obj) {
+    return obj.id == currencyId;
+  });
+
+  return parseFloat(currencyData[0].price_usd);
 }
 
 function getWebRate(currencyId) {


### PR DESCRIPTION
Added getApiObj() function to get all API data one time
Modified getRate function and coin variable declarations to use apiObj object
This should reduce API fetch to once per script run rather than fetching for every coin

I'm new to pull requests so apologies if I'm doing something wrong!
I think this would help with [issue 12](https://github.com/saitei/crypto-sheets/issues/12)